### PR TITLE
add options

### DIFF
--- a/xml2js-es6-promise.js
+++ b/xml2js-es6-promise.js
@@ -1,8 +1,8 @@
 var xml2js = require('xml2js');
 
-module.exports = function(input) {
+module.exports = function(input, options) {
     return new Promise(function(resolve, reject) {
-        xml2js.parseString(input, function(err, result) {
+        xml2js.parseString(input, options, function(err, result) {
             if (!err) {
                 resolve(result);
             } else {


### PR DESCRIPTION
Allow to use xml2js options
e.g.
`xml('<root> Hello xml2js!</root>', {trim: false}).then(function(js) {
  console.log(JSON.stringify(js));
});`
